### PR TITLE
Remove arr! macro as it generates huge amount of LLVM IR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ fx-hash = ["rustc-hash"]
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"] , optional = true}
-arr_macro = "0.1"
 fnv = { version = "1.0", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 crossbeam-channel = {version="0.4", optional = true}

--- a/src/wheels/byte_wheel.rs
+++ b/src/wheels/byte_wheel.rs
@@ -25,25 +25,24 @@ pub struct WheelEntry<EntryType, RestType> {
 pub type WheelEntryList<EntryType, RestType> = Vec<WheelEntry<EntryType, RestType>>;
 
 /// Number of slots for each ByteWheel
-const SLOTS: usize = 256;
+const NUM_SLOTS: usize = 256;
 
 /// A single wheel with 256 slots of for elements of `EntryType`
 ///
 /// The `RestType` us used to store an array of bytes that are the rest of the delay.
 /// This way the same wheel structure can be used at different hierarchical levels.
 pub struct ByteWheel<EntryType, RestType> {
-    slots: Box<[Option<WheelEntryList<EntryType, RestType>>]>,
+    slots: [Option<WheelEntryList<EntryType, RestType>>; NUM_SLOTS],
     count: u64,
     current: u8,
 }
 
 impl<EntryType, RestType> ByteWheel<EntryType, RestType> {
+    const INIT_VALUE: Option<WheelEntryList<EntryType, RestType>> = None;
+
     /// Create a new empty ByteWheel
     pub fn new() -> Self {
-        let slots: Box<[Option<WheelEntryList<EntryType, RestType>>]> = (0..SLOTS)
-            .map(|_| Option::None)
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+        let slots: [Option<WheelEntryList<EntryType, RestType>>; NUM_SLOTS] = [Self::INIT_VALUE; NUM_SLOTS];
 
         ByteWheel {
             slots,

--- a/src/wheels/byte_wheel.rs
+++ b/src/wheels/byte_wheel.rs
@@ -12,7 +12,6 @@
 //!
 //! # Example
 //! Example usage of this abstraction can be seen in the source code of the [quad_wheel](crate::wheels::quad_wheel::QuadWheelWithOverflow).
-use arr_macro::arr;
 
 /// A single entry in a slot
 pub struct WheelEntry<EntryType, RestType> {
@@ -25,12 +24,15 @@ pub struct WheelEntry<EntryType, RestType> {
 /// Just a convenience type alias for the list type used in each slot
 pub type WheelEntryList<EntryType, RestType> = Vec<WheelEntry<EntryType, RestType>>;
 
+/// Number of slots for each ByteWheel
+const SLOTS: usize = 256;
+
 /// A single wheel with 256 slots of for elements of `EntryType`
 ///
 /// The `RestType` us used to store an array of bytes that are the rest of the delay.
 /// This way the same wheel structure can be used at different hierarchical levels.
 pub struct ByteWheel<EntryType, RestType> {
-    slots: [Option<WheelEntryList<EntryType, RestType>>; 256],
+    slots: Box<[Option<WheelEntryList<EntryType, RestType>>]>,
     count: u64,
     current: u8,
 }
@@ -38,7 +40,11 @@ pub struct ByteWheel<EntryType, RestType> {
 impl<EntryType, RestType> ByteWheel<EntryType, RestType> {
     /// Create a new empty ByteWheel
     pub fn new() -> Self {
-        let slots: [Option<WheelEntryList<EntryType, RestType>>; 256] = arr![Option::None; 256];
+        let slots: Box<[Option<WheelEntryList<EntryType, RestType>>]> = (0..SLOTS)
+            .map(|_| Option::None)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
         ByteWheel {
             slots,
             count: 0,

--- a/src/wheels/quad_wheel.rs
+++ b/src/wheels/quad_wheel.rs
@@ -103,10 +103,10 @@ pub struct QuadWheelWithOverflow<EntryType>
 where
     EntryType: Debug,
 {
-    primary: ByteWheel<EntryType, [u8; 0]>,
-    secondary: ByteWheel<EntryType, [u8; 1]>,
-    tertiary: ByteWheel<EntryType, [u8; 2]>,
-    quarternary: ByteWheel<EntryType, [u8; 3]>,
+    primary: Box<ByteWheel<EntryType, [u8; 0]>>,
+    secondary: Box<ByteWheel<EntryType, [u8; 1]>>,
+    tertiary: Box<ByteWheel<EntryType, [u8; 2]>>,
+    quarternary: Box<ByteWheel<EntryType, [u8; 3]>>,
     overflow: Vec<OverflowEntry<EntryType>>,
     pruner: fn(&EntryType) -> PruneDecision,
 }
@@ -144,10 +144,10 @@ where
     /// Create a new wheel
     pub fn new(pruner: fn(&EntryType) -> PruneDecision) -> Self {
         QuadWheelWithOverflow {
-            primary: ByteWheel::new(),
-            secondary: ByteWheel::new(),
-            tertiary: ByteWheel::new(),
-            quarternary: ByteWheel::new(),
+            primary: Box::new(ByteWheel::new()),
+            secondary: Box::new(ByteWheel::new()),
+            tertiary: Box::new(ByteWheel::new()),
+            quarternary: Box::new(ByteWheel::new()),
             overflow: Vec::new(),
             pruner,
         }


### PR DESCRIPTION
I executed ``cargo llvm-lines`` on Arcon and Kompact and thought it was strange that ``ByteWheel::New`` stood for quite a large part of the generated LLVM IR. See below.

![wheel_old](https://user-images.githubusercontent.com/11488530/126957601-b77188cf-aa32-4361-9241-5771b21677d7.PNG)
and Kompact:
![kompact_1](https://user-images.githubusercontent.com/11488530/126957678-3fdb2c04-3302-42d6-9a2c-b31e8cfc807c.PNG)


I am not sure what is happening in that arr_macro but by turning the slots into a Boxed slice, it now looks like this:

![wheel_actual_2](https://user-images.githubusercontent.com/11488530/126958096-38f91459-2b04-40fa-b770-c91d070d75cf.PNG)


I ran cargo bench to see if performance was affected, but it looked like it even got better for most parts. But this should be checked again perhaps.  The big win  here is compile time. A release kompact build on my desktop went from 1 min to 42s after the change.